### PR TITLE
Replace API server polling with informer-based approach for Numatopologies resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/client-go v0.19.6
 	k8s.io/component-base v0.19.6
 	k8s.io/klog v1.0.0
+	k8s.io/klog/v2 v2.2.0
 	k8s.io/kubelet v0.19.6
 	k8s.io/kubernetes v1.19.6
 	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009 // indirect

--- a/main.go
+++ b/main.go
@@ -78,15 +78,8 @@ func main() {
 	// This uses list-watch mechanism instead of polling
 	numaCache := numatopo.NewNumatopoCache(nodeInfoClient, hostname)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	shutdownCh := make(chan os.Signal, 1)
-	signal.Notify(shutdownCh, syscall.SIGINT, syscall.SIGTERM)
-	defer signal.Stop(shutdownCh)
-	go func() {
-		<-shutdownCh
-		cancel()
-	}()
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 	stopCh := ctx.Done()
 
 	// Start the informer (non-blocking, runs in background goroutine)

--- a/main.go
+++ b/main.go
@@ -76,7 +76,7 @@ func main() {
 
 	// Initialize Numatopology informer cache
 	// This uses list-watch mechanism instead of polling
-	numaCache := numatopo.NewNumatopoCache(nodeInfoClient, hostname, opt.CheckInterval)
+	numaCache := numatopo.NewNumatopoCache(nodeInfoClient, hostname)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/main.go
+++ b/main.go
@@ -22,10 +22,9 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-
 	"k8s.io/apimachinery/pkg/util/wait"
 	cliflag "k8s.io/component-base/cli/flag"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"volcano.sh/apis/pkg/client/clientset/versioned"
 	"volcano.sh/resource-exporter/pkg/args"
@@ -90,7 +89,6 @@ func main() {
 	klog.V(2).Infof("Numatopology informer cache synced successfully")
 
 	// Use wait.UntilWithContext to periodically check and update Numatopology
-	// This replaces the manual for-select loop with ticker
 	wait.UntilWithContext(context.TODO(), func(ctx context.Context) {
 		// Get current resource from informer cache
 		cached, err := numaCache.Get()
@@ -98,6 +96,7 @@ func main() {
 
 		// Check local file changes (kubelet cpu_manager_state, etc.)
 		isChg := numatopo.NodeInfoRefresh(opt)
+		klog.V(4).Infof("Local file changes within the interval: %v", isChg)
 
 		// Create or update if there are changes or resource doesn't exist
 		if isChg || !exist {

--- a/main.go
+++ b/main.go
@@ -19,9 +19,12 @@ package main
 import (
 	"context"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/spf13/pflag"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
@@ -75,9 +78,16 @@ func main() {
 	// This uses list-watch mechanism instead of polling
 	numaCache := numatopo.NewNumatopoCache(nodeInfoClient, hostname, opt.CheckInterval)
 
-	// Create stop channel for graceful shutdown
-	stopCh := make(chan struct{})
-	defer close(stopCh)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	shutdownCh := make(chan os.Signal, 1)
+	signal.Notify(shutdownCh, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(shutdownCh)
+	go func() {
+		<-shutdownCh
+		cancel()
+	}()
+	stopCh := ctx.Done()
 
 	// Start the informer (non-blocking, runs in background goroutine)
 	numaCache.Start(stopCh)
@@ -89,10 +99,18 @@ func main() {
 	klog.V(2).Infof("Numatopology informer cache synced successfully")
 
 	// Use wait.UntilWithContext to periodically check and update Numatopology
-	wait.UntilWithContext(context.TODO(), func(ctx context.Context) {
+	wait.UntilWithContext(ctx, func(ctx context.Context) {
 		// Get current resource from informer cache
 		cached, err := numaCache.Get()
-		exist := err == nil && cached != nil
+		exist := true
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				exist = false
+			} else {
+				klog.Errorf("Get Numatopology from cache failed, err=%v", err)
+				return
+			}
+		}
 
 		// Check local file changes (kubelet cpu_manager_state, etc.)
 		isChg := numatopo.NodeInfoRefresh(opt)

--- a/main.go
+++ b/main.go
@@ -17,15 +17,11 @@ limitations under the License.
 package main
 
 import (
-	"context"
-	"fmt"
 	"os"
 	"time"
 
 	"github.com/spf13/pflag"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog"
@@ -47,24 +43,6 @@ func getNumaTopoClient(argument *args.Argument) (*versioned.Clientset, error) {
 	return versioned.NewForConfigOrDie(config), err
 }
 
-func numatopoIsExist(client *versioned.Clientset) (bool, error) {
-	hostname := os.Getenv("MY_NODE_NAME")
-	if hostname == "" {
-		return false, fmt.Errorf("get Hostname failed")
-	}
-
-	_, err := client.NodeinfoV1alpha1().Numatopologies().Get(context.TODO(), hostname, metav1.GetOptions{})
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			return false, err
-		}
-
-		return false, nil
-	}
-
-	return true, nil
-}
-
 func main() {
 	klog.InitFlags(nil)
 
@@ -81,26 +59,48 @@ func main() {
 		klog.Fatal(err)
 	}
 
+	// Get hostname from environment variable
+	hostname := os.Getenv("MY_NODE_NAME")
+	if hostname == "" {
+		klog.Fatal("MY_NODE_NAME environment variable is required")
+	}
+
 	nodeInfoClient, err := getNumaTopoClient(opt)
 	if err != nil {
 		klog.Errorf("Get numainfo client failed, err = %v", err)
 		return
 	}
 
+	// Initialize Numatopology informer cache
+	// This uses list-watch mechanism instead of polling
+	numaCache := numatopo.NewNumatopoCache(nodeInfoClient, hostname, opt.CheckInterval)
+
+	// Create stop channel for graceful shutdown
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	// Start the informer (non-blocking, runs in background goroutine)
+	numaCache.Start(stopCh)
+
+	// Wait for informer cache to sync (blocking until initial list is complete)
+	if !numaCache.WaitForCacheSync(stopCh) {
+		klog.Fatal("Failed to sync Numatopology informer cache")
+	}
+	klog.V(2).Infof("Numatopology informer cache synced successfully")
+
 	tick := time.NewTicker(opt.CheckInterval)
 	for {
 		select {
 		case <-tick.C:
-			exist, err := numatopoIsExist(nodeInfoClient)
-			if err != nil {
-				klog.Errorf("Get numatopo failed, err= %v", err)
-				continue
-			}
+			cached, err := numaCache.Get()
+			exist := err == nil && cached != nil
 
+			// Check local file changes (kubelet cpu_manager_state, etc.)
 			isChg := numatopo.NodeInfoRefresh(opt)
+
 			if isChg || !exist {
-				klog.V(4).Infof("Node info changes.")
-				numatopo.CreateOrUpdateNumatopo(nodeInfoClient)
+				klog.V(4).Infof("Node info changes detected, updating Numatopology.")
+				numatopo.CreateOrUpdateNumatopo(nodeInfoClient, cached)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"os"
 	"time"
 
@@ -88,20 +89,20 @@ func main() {
 	}
 	klog.V(2).Infof("Numatopology informer cache synced successfully")
 
-	tick := time.NewTicker(opt.CheckInterval)
-	for {
-		select {
-		case <-tick.C:
-			cached, err := numaCache.Get()
-			exist := err == nil && cached != nil
+	// Use wait.UntilWithContext to periodically check and update Numatopology
+	// This replaces the manual for-select loop with ticker
+	wait.UntilWithContext(context.TODO(), func(ctx context.Context) {
+		// Get current resource from informer cache
+		cached, err := numaCache.Get()
+		exist := err == nil && cached != nil
 
-			// Check local file changes (kubelet cpu_manager_state, etc.)
-			isChg := numatopo.NodeInfoRefresh(opt)
+		// Check local file changes (kubelet cpu_manager_state, etc.)
+		isChg := numatopo.NodeInfoRefresh(opt)
 
-			if isChg || !exist {
-				klog.V(4).Infof("Node info changes detected, updating Numatopology.")
-				numatopo.CreateOrUpdateNumatopo(nodeInfoClient, cached)
-			}
+		// Create or update if there are changes or resource doesn't exist
+		if isChg || !exist {
+			klog.V(4).Infof("Node info changes detected, updating Numatopology.")
+			numatopo.CreateOrUpdateNumatopo(nodeInfoClient, cached)
 		}
-	}
+	}, opt.CheckInterval)
 }

--- a/pkg/numatopo/informer.go
+++ b/pkg/numatopo/informer.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2021 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package numatopo
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+
+	"volcano.sh/apis/pkg/apis/nodeinfo/v1alpha1"
+	"volcano.sh/apis/pkg/client/clientset/versioned"
+	informers "volcano.sh/apis/pkg/client/informers/externalversions"
+	listers "volcano.sh/apis/pkg/client/listers/nodeinfo/v1alpha1"
+)
+
+// NumatopoCache manages the informer and lister for Numatopology resources.
+// It provides a local cache to avoid frequent API server calls.
+type NumatopoCache struct {
+	factory  informers.SharedInformerFactory
+	lister   listers.NumatopologyLister
+	informer cache.SharedIndexInformer
+	nodeName string
+}
+
+// NewNumatopoCache creates a new NumatopoCache with filtered informer.
+// The informer only watches the Numatopology resource for the specified node.
+func NewNumatopoCache(client versioned.Interface, nodeName string, resyncPeriod time.Duration) *NumatopoCache {
+	// Use FieldSelector to filter, only watch the current node's resource
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		client,
+		resyncPeriod,
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", nodeName).String()
+		}),
+	)
+
+	numaInformer := factory.Nodeinfo().V1alpha1().Numatopologies()
+
+	c := &NumatopoCache{
+		factory:  factory,
+		lister:   numaInformer.Lister(),
+		informer: numaInformer.Informer(),
+		nodeName: nodeName,
+	}
+
+	// Add event handlers for logging (optional, useful for debugging)
+	numaInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			numa := obj.(*v1alpha1.Numatopology)
+			klog.V(4).Infof("Numatopology added to cache: %s", numa.Name)
+		},
+		UpdateFunc: func(oldObj, newObj interface{}) {
+			oldNuma := oldObj.(*v1alpha1.Numatopology)
+			newNuma := newObj.(*v1alpha1.Numatopology)
+			klog.V(4).Infof("Numatopology updated in cache: %s, ResourceVersion: %s -> %s",
+				newNuma.Name, oldNuma.ResourceVersion, newNuma.ResourceVersion)
+		},
+		DeleteFunc: func(obj interface{}) {
+			numa := obj.(*v1alpha1.Numatopology)
+			klog.V(4).Infof("Numatopology deleted from cache: %s", numa.Name)
+		},
+	})
+
+	return c
+}
+
+// Start starts the informer goroutine.
+// This method is non-blocking and starts the list-watch mechanism in background.
+func (c *NumatopoCache) Start(stopCh <-chan struct{}) {
+	klog.V(2).Infof("Starting Numatopology informer for node %s", c.nodeName)
+	c.factory.Start(stopCh)
+}
+
+// WaitForCacheSync waits for the informer cache to be synced.
+// Returns true if the cache was synced successfully, false otherwise.
+func (c *NumatopoCache) WaitForCacheSync(stopCh <-chan struct{}) bool {
+	klog.V(2).Infof("Waiting for Numatopology informer cache to sync")
+	return cache.WaitForCacheSync(stopCh, c.informer.HasSynced)
+}
+
+// Get retrieves the Numatopology resource for the current node from local cache.
+// This method does not make any API calls - it reads from the local cache.
+// Returns nil if the resource does not exist in the cache.
+func (c *NumatopoCache) Get() (*v1alpha1.Numatopology, error) {
+	return c.lister.Get(c.nodeName)
+}
+
+// HasSynced returns true if the informer cache has been synced at least once.
+func (c *NumatopoCache) HasSynced() bool {
+	return c.informer.HasSynced()
+}

--- a/pkg/numatopo/informer.go
+++ b/pkg/numatopo/informer.go
@@ -17,8 +17,6 @@ limitations under the License.
 package numatopo
 
 import (
-	"time"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
@@ -41,11 +39,11 @@ type NumatopoCache struct {
 
 // NewNumatopoCache creates a new NumatopoCache with filtered informer.
 // The informer only watches the Numatopology resource for the specified node.
-func NewNumatopoCache(client versioned.Interface, nodeName string, resyncPeriod time.Duration) *NumatopoCache {
+func NewNumatopoCache(client versioned.Interface, nodeName string) *NumatopoCache {
 	// Use FieldSelector to filter, only watch the current node's resource
 	factory := informers.NewSharedInformerFactoryWithOptions(
 		client,
-		resyncPeriod,
+		0,
 		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
 			options.FieldSelector = fields.OneTermEqualSelector("metadata.name", nodeName).String()
 		}),

--- a/pkg/numatopo/informer.go
+++ b/pkg/numatopo/informer.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Volcano Authors.
+Copyright 2026 The Volcano Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"volcano.sh/apis/pkg/apis/nodeinfo/v1alpha1"
 	"volcano.sh/apis/pkg/client/clientset/versioned"
@@ -59,24 +59,6 @@ func NewNumatopoCache(client versioned.Interface, nodeName string, resyncPeriod 
 		informer: numaInformer.Informer(),
 		nodeName: nodeName,
 	}
-
-	// Add event handlers for logging (optional, useful for debugging)
-	numaInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			numa := obj.(*v1alpha1.Numatopology)
-			klog.V(4).Infof("Numatopology added to cache: %s", numa.Name)
-		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
-			oldNuma := oldObj.(*v1alpha1.Numatopology)
-			newNuma := newObj.(*v1alpha1.Numatopology)
-			klog.V(4).Infof("Numatopology updated in cache: %s, ResourceVersion: %s -> %s",
-				newNuma.Name, oldNuma.ResourceVersion, newNuma.ResourceVersion)
-		},
-		DeleteFunc: func(obj interface{}) {
-			numa := obj.(*v1alpha1.Numatopology)
-			klog.V(4).Infof("Numatopology deleted from cache: %s", numa.Name)
-		},
-	})
 
 	return c
 }

--- a/pkg/numatopo/reservation_test.go
+++ b/pkg/numatopo/reservation_test.go
@@ -17,14 +17,19 @@ limitations under the License.
 package numatopo
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
 	machineinfov1 "github.com/google/cadvisor/info/v1"
+	nodeinfov1alpha1 "volcano.sh/apis/pkg/apis/nodeinfo/v1alpha1"
+	"volcano.sh/apis/pkg/client/clientset/versioned/fake"
 )
 
 const (
@@ -98,5 +103,45 @@ func TestReservationCalculation(t *testing.T) {
 				t.Errorf("expect: %v, got: %v", pq, reservation[metric])
 			}
 		}
+	}
+}
+
+func TestCreateOrUpdateNumatopoUpdatesExistingResourceWhenCreateAlreadyExists(t *testing.T) {
+	const nodeName = "node-a"
+
+	oldNodeName, hadNodeName := os.LookupEnv("MY_NODE_NAME")
+	if err := os.Setenv("MY_NODE_NAME", nodeName); err != nil {
+		t.Fatalf("failed to set MY_NODE_NAME: %v", err)
+	}
+	defer func() {
+		if hadNodeName {
+			_ = os.Setenv("MY_NODE_NAME", oldNodeName)
+		} else {
+			_ = os.Unsetenv("MY_NODE_NAME")
+		}
+	}()
+
+	client := fake.NewSimpleClientset(&nodeinfov1alpha1.Numatopology{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nodeName,
+		},
+		Spec: nodeinfov1alpha1.NumatopoSpec{
+			Policies: map[nodeinfov1alpha1.PolicyName]string{
+				nodeinfov1alpha1.CPUManagerPolicy: "stale",
+			},
+		},
+	})
+
+	CreateOrUpdateNumatopo(client, nil)
+
+	updated, err := client.NodeinfoV1alpha1().Numatopologies().Get(context.TODO(), nodeName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get updated Numatopology: %v", err)
+	}
+	if updated.Annotations["timestamp"] == "" {
+		t.Fatalf("expected timestamp annotation to be set after update")
+	}
+	if updated.Spec.Policies[nodeinfov1alpha1.CPUManagerPolicy] == "stale" {
+		t.Fatalf("expected existing Numatopology spec to be updated")
 	}
 }

--- a/pkg/numatopo/update.go
+++ b/pkg/numatopo/update.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"time"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 
@@ -45,22 +44,20 @@ func NodeInfoRefresh(opt *args.Argument) bool {
 	return isChange || TopoInfoUpdate(opt)
 }
 
-// CreateOrUpdateNumatopo create or update the numatopo to etcd
-func CreateOrUpdateNumatopo(client *versioned.Clientset) {
+// CreateOrUpdateNumatopo creates or updates the numatopo to etcd.
+// The cached parameter is the Numatopology resource from the informer cache.
+// If cached is nil, a new resource will be created.
+// If cached is not nil, the resource will be updated.
+func CreateOrUpdateNumatopo(client *versioned.Clientset, cached *v1alpha1.Numatopology) {
 	hostname := os.Getenv("MY_NODE_NAME")
 	if hostname == "" {
 		klog.Errorf("Get env MY_NODE_NAME failed.")
 		return
 	}
 
-	numaInfo, err := client.NodeinfoV1alpha1().Numatopologies().Get(context.TODO(), hostname, metav1.GetOptions{})
-	if err != nil {
-		if !apierrors.IsNotFound(err) {
-			klog.Errorf("Get Numatopo for node %s failed, err=%v", hostname, err)
-			return
-		}
-
-		numaInfo = &v1alpha1.Numatopology{
+	if cached == nil {
+		// Resource does not exist in cache, create a new one
+		numaInfo := &v1alpha1.Numatopology{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: hostname,
 			},
@@ -72,11 +69,15 @@ func CreateOrUpdateNumatopo(client *versioned.Clientset) {
 			},
 		}
 
-		_, err = client.NodeinfoV1alpha1().Numatopologies().Create(context.TODO(), numaInfo, metav1.CreateOptions{})
+		_, err := client.NodeinfoV1alpha1().Numatopologies().Create(context.TODO(), numaInfo, metav1.CreateOptions{})
 		if err != nil {
 			klog.Errorf("Create Numatopo for node %s failed, err=%v", hostname, err)
+		} else {
+			klog.V(4).Infof("Created Numatopo for node %s successfully", hostname)
 		}
 	} else {
+		// Resource exists in cache, update it
+		numaInfo := cached.DeepCopy()
 		numaInfo.Spec = v1alpha1.NumatopoSpec{
 			Policies:    GetPolicy(),
 			ResReserved: GetResReserved(),
@@ -89,9 +90,11 @@ func CreateOrUpdateNumatopo(client *versioned.Clientset) {
 		// use to trigger CR numa update
 		numaInfo.Annotations["timestamp"] = fmt.Sprint(time.Now().Unix())
 
-		_, err = client.NodeinfoV1alpha1().Numatopologies().Update(context.TODO(), numaInfo, metav1.UpdateOptions{})
+		_, err := client.NodeinfoV1alpha1().Numatopologies().Update(context.TODO(), numaInfo, metav1.UpdateOptions{})
 		if err != nil {
 			klog.Errorf("Update Numatopo for node %s failed, err=%v", hostname, err)
+		} else {
+			klog.V(4).Infof("Updated Numatopo for node %s successfully", hostname)
 		}
 	}
 }

--- a/pkg/numatopo/update.go
+++ b/pkg/numatopo/update.go
@@ -23,10 +23,11 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog"
+	"k8s.io/klog/v2"
 
 	"volcano.sh/apis/pkg/apis/nodeinfo/v1alpha1"
 	"volcano.sh/apis/pkg/client/clientset/versioned"
+
 	"volcano.sh/resource-exporter/pkg/args"
 )
 
@@ -41,7 +42,11 @@ func NodeInfoRefresh(opt *args.Argument) bool {
 		isChange = TryUpdatingResourceReservation(klConfig, opt.ResReserved)
 	}
 
-	return isChange || TopoInfoUpdate(opt)
+	if TopoInfoUpdate(opt) {
+		isChange = true
+	}
+
+	return isChange
 }
 
 // CreateOrUpdateNumatopo creates or updates the numatopo to etcd.

--- a/pkg/numatopo/update.go
+++ b/pkg/numatopo/update.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
@@ -53,7 +54,7 @@ func NodeInfoRefresh(opt *args.Argument) bool {
 // The cached parameter is the Numatopology resource from the informer cache.
 // If cached is nil, a new resource will be created.
 // If cached is not nil, the resource will be updated.
-func CreateOrUpdateNumatopo(client *versioned.Clientset, cached *v1alpha1.Numatopology) {
+func CreateOrUpdateNumatopo(client versioned.Interface, cached *v1alpha1.Numatopology) {
 	hostname := os.Getenv("MY_NODE_NAME")
 	if hostname == "" {
 		klog.Errorf("Get env MY_NODE_NAME failed.")
@@ -76,30 +77,41 @@ func CreateOrUpdateNumatopo(client *versioned.Clientset, cached *v1alpha1.Numato
 
 		_, err := client.NodeinfoV1alpha1().Numatopologies().Create(context.TODO(), numaInfo, metav1.CreateOptions{})
 		if err != nil {
-			klog.Errorf("Create Numatopo for node %s failed, err=%v", hostname, err)
-		} else {
-			klog.V(4).Infof("Created Numatopo for node %s successfully", hostname)
-		}
-	} else {
-		// Resource exists in cache, update it
-		numaInfo := cached.DeepCopy()
-		numaInfo.Spec = v1alpha1.NumatopoSpec{
-			Policies:    GetPolicy(),
-			ResReserved: GetResReserved(),
-			NumaResMap:  GetAllResAllocatableInfo(),
-			CPUDetail:   GetCpusDetail(),
-		}
-		if numaInfo.Annotations == nil {
-			numaInfo.Annotations = make(map[string]string)
-		}
-		// use to trigger CR numa update
-		numaInfo.Annotations["timestamp"] = fmt.Sprint(time.Now().Unix())
+			if !apierrors.IsAlreadyExists(err) {
+				klog.Errorf("Create Numatopo for node %s failed, err=%v", hostname, err)
+				return
+			}
 
-		_, err := client.NodeinfoV1alpha1().Numatopologies().Update(context.TODO(), numaInfo, metav1.UpdateOptions{})
-		if err != nil {
-			klog.Errorf("Update Numatopo for node %s failed, err=%v", hostname, err)
+			cached, err = client.NodeinfoV1alpha1().Numatopologies().Get(context.TODO(), hostname, metav1.GetOptions{})
+			if err != nil {
+				klog.Errorf("Get existing Numatopo for node %s failed, err=%v", hostname, err)
+				return
+			}
 		} else {
-			klog.V(4).Infof("Updated Numatopo for node %s successfully", hostname)
+			// Create succeeded, no immediate update is needed.
+			klog.V(4).Infof("Created Numatopo for node %s successfully", hostname)
+			return
 		}
+	}
+
+	// Resource exists in cache, update it
+	numaInfo := cached.DeepCopy()
+	numaInfo.Spec = v1alpha1.NumatopoSpec{
+		Policies:    GetPolicy(),
+		ResReserved: GetResReserved(),
+		NumaResMap:  GetAllResAllocatableInfo(),
+		CPUDetail:   GetCpusDetail(),
+	}
+	if numaInfo.Annotations == nil {
+		numaInfo.Annotations = make(map[string]string)
+	}
+	// use to trigger CR numa update
+	numaInfo.Annotations["timestamp"] = fmt.Sprint(time.Now().Unix())
+
+	_, err := client.NodeinfoV1alpha1().Numatopologies().Update(context.TODO(), numaInfo, metav1.UpdateOptions{})
+	if err != nil {
+		klog.Errorf("Update Numatopo for node %s failed, err=%v", hostname, err)
+	} else {
+		klog.V(4).Infof("Updated Numatopo for node %s successfully", hostname)
 	}
 }


### PR DESCRIPTION
## Summary

  - Replaces per-interval API Server polling for Numatopologies with an informer-backed local cache
  - Adds a filtered NumatopoCache that watches only the current node's Numatopology resource
  - Removes the direct Get()-based existence check from the main reconciliation loop
  - Updates CreateOrUpdateNumatopo() to use the informer-cached object instead of fetching from the API Server
  - Keeps the existing local node resource refresh behavior for kubelet/sysfs changes
  - Rewrites the main loop with wait.UntilWithContext for idiomatic periodic reconciliation

  ## Related Issues

  - Reduces API Server load caused by DaemonSet-wide polling of Numatopologies
  - Improves scalability for large clusters with thousands of nodes

  ## Design

  ### Informer-based Numatopology cache

  The previous implementation queried the API Server every --check-period to determine whether the current node's Numatopology resource existed. Since this exporter runs
  as a DaemonSet, that pattern scales linearly with node count and creates sustained API Server pressure.

  This PR introduces NumatopoCache, which uses Volcano's generated informer client to establish a list-watch stream and maintain a local cache. The informer is filtered
  by metadata.name == MY_NODE_NAME, so each pod only watches the Numatopology object for its own node.

  The main loop now checks existence through the local lister cache instead of issuing a Kubernetes API Get() request.

  ### Local refresh remains periodic

  The exporter still needs to inspect local node state, including kubelet config, cpu_manager_state, and sysfs NUMA topology files. That local refresh remains periodic
  and continues to use the existing --check-period flag.

  The key change is that the periodic loop no longer performs read queries against the API Server. API writes only happen when local node information changes or the CR
  does not exist in the informer cache.

  ### Create/update without redundant GET

  CreateOrUpdateNumatopo() now accepts the cached Numatopology object:

  - nil cache object: create a new CR for the current node
  - non-nil cache object: deep-copy it, update the spec and timestamp annotation, then submit an update

  This removes the extra API Get() previously performed inside the update path.

  ## Changes
  │ Area                     │ What changed                                                                                                         │

  │ main.go                  │ Removed numatopoIsExist() API polling, starts informer cache, waits for cache sync, reads existence from local cache │
  │ pkg/numatopo/informer.go │ Added NumatopoCache wrapper around shared informer, lister, cache sync, and node-name field filtering                │
  │ pkg/numatopo/update.go   │ CreateOrUpdateNumatopo() now uses the cached object instead of fetching before create/update                         │
  │ Reconciliation loop      │ Replaced manual ticker/select loop with wait.UntilWithContext                                                        

  ## Benefits

  - Reduces recurring API Server read load from N nodes × 1 query / check-period to informer list-watch cache reads
  - Avoids redundant Get() calls for unchanged resources
  - Keeps remote resource state up to date through watch events
  - Preserves existing behavior for local node topology change detection
  - Uses standard Kubernetes controller patterns via client-go informers

  ## Implementation Notes

  The existing RBAC already grants watch permission for numatopologies, so no manifest permission changes are required.

  This PR does not remove periodic local file checks. It specifically replaces API Server polling with informer cache lookup while keeping the existing local
  reconciliation cadence.

  ## AI Assistance Disclosure

  This PR was developed with AI guidance. The author reviewed, directed, and validated all changes carefully.

  ## Closes

  - Closes #11 