### PR TITLE
feat: Add PodResources API support for NUMA topology reporting and enhance CPU allocation visibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	k8s.io/kubernetes v1.35.3
 	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	sigs.k8s.io/yaml v1.6.0
-	volcano.sh/apis v1.15.0
+	volcano.sh/apis v1.15.1-0.20260622062552-536f121f5365
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/cadvisor v0.53.0
 	github.com/spf13/pflag v1.0.9
 	golang.org/x/time v0.11.0 // indirect
+	google.golang.org/grpc v1.72.2
 	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3
@@ -108,7 +109,6 @@ require (
 	golang.org/x/text v0.31.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250303144028-a0af3efb3deb // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250528174236-200df99c418a // indirect
-	google.golang.org/grpc v1.72.2 // indirect
 	google.golang.org/protobuf v1.36.8 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -334,5 +334,5 @@ sigs.k8s.io/structured-merge-diff/v6 v6.3.0 h1:jTijUJbW353oVOd9oTlifJqOGEkUw2jB/
 sigs.k8s.io/structured-merge-diff/v6 v6.3.0/go.mod h1:M3W8sfWvn2HhQDIbGWj3S099YozAsymCo/wrT5ohRUE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
 sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=
-volcano.sh/apis v1.15.0 h1:6FhJSfowMWfpRVVAsSrFF91FW06l64AlRfAxfNWWyKo=
-volcano.sh/apis v1.15.0/go.mod h1:rIDP5D1IR0Tq0uGIMCjMdTEDXMzyTMbwlXhxtMdxLls=
+volcano.sh/apis v1.15.1-0.20260622062552-536f121f5365 h1:gKYnLz8BhSWibuoasG5S7+y+L9HdD/NyE/20C2aetkE=
+volcano.sh/apis v1.15.1-0.20260622062552-536f121f5365/go.mod h1:rIDP5D1IR0Tq0uGIMCjMdTEDXMzyTMbwlXhxtMdxLls=

--- a/installer/numa-topo.yaml
+++ b/installer/numa-topo.yaml
@@ -63,6 +63,8 @@ spec:
             - --kubelet-conf=/host/kubeletconf/config.yaml
             - --cpu-manager-state=/host/kubelet/cpu_manager_state
             - --device-path=/host/device
+            - --pod-resource-sock=/host/podresources
+            - --enable-pod-resource=true
             - -v=4
             - 2>&1
           env:
@@ -77,6 +79,9 @@ spec:
               mountPath: "/host/kubelet"
             - name: kubelet-config-path
               mountPath: "/host/kubeletconf"
+            - name: pod-resources-sock
+              mountPath: "/host/podresources"
+              readOnly: true
       volumes:
         - name: node-path
           hostPath:
@@ -87,3 +92,6 @@ spec:
         - name: kubelet-config-path
           hostPath:
             path: "/var/lib/kubelet"
+        - name: pod-resources-sock
+          hostPath:
+            path: /var/lib/kubelet/pod-resources

--- a/main.go
+++ b/main.go
@@ -75,11 +75,20 @@ func main() {
 		return
 	}
 
-	err = numatopo.InitPodResourcesClient(opt.PodResourceSockPath)
-	if err != nil {
-		klog.Errorf("Failed to init podresources client: %v", err)
+	if opt.EnableGetCpuIDByPodResourceList {
+		err = numatopo.InitPodResourcesClient(opt.PodResourceSockPath)
+		if err != nil {
+			// Fall back to the cpu_manager_state file-based method instead of
+			// leaving the client nil: a nil client would make every NUMA
+			// allocation update fail, so the node topology would silently stop
+			// being reported. Degrading keeps the daemon reporting, just via the
+			// legacy (less reliable) source.
+			klog.Errorf("Failed to init podresources client, falling back to cpu_manager_state method: %v", err)
+			opt.EnableGetCpuIDByPodResourceList = false
+		} else {
+			defer numatopo.ClosePodResourcesClient()
+		}
 	}
-	defer numatopo.ClosePodResourcesClient()
 
 	// Initialize Numatopology informer cache
 	// This uses list-watch mechanism instead of polling

--- a/main.go
+++ b/main.go
@@ -112,11 +112,11 @@ func main() {
 			}
 		}
 
-		// Check local file changes (kubelet cpu_manager_state, etc.)
+		// Check local resource changes, including kubelet config, node numa topologies and pod resource allocations
 		isChg := numatopo.NodeInfoRefresh(opt)
-		klog.V(4).Infof("Local file changes within the interval: %v", isChg)
+		klog.V(4).Infof("Local resource changes within the interval: %v", isChg)
 
-		// Create or update if there are changes or resource doesn't exist
+		// Create or update if there are changes or resources non-existent
 		if isChg || !exist {
 			klog.V(4).Infof("Node info changes detected, updating Numatopology.")
 			numatopo.CreateOrUpdateNumatopo(nodeInfoClient, cached)

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"volcano.sh/apis/pkg/client/clientset/versioned"
+
 	"volcano.sh/resource-exporter/pkg/args"
 	"volcano.sh/resource-exporter/pkg/machineinfo"
 	"volcano.sh/resource-exporter/pkg/numatopo"
@@ -73,6 +74,12 @@ func main() {
 		klog.Errorf("Get numainfo client failed, err = %v", err)
 		return
 	}
+
+	err = numatopo.InitPodResourcesClient(opt.PodResourceSockPath)
+	if err != nil {
+		klog.Errorf("Failed to init podresources client: %v", err)
+	}
+	defer numatopo.ClosePodResourcesClient()
 
 	// Initialize Numatopology informer cache
 	// This uses list-watch mechanism instead of polling

--- a/pkg/args/args.go
+++ b/pkg/args/args.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -22,12 +21,16 @@ type ClientOptions struct {
 
 // Argument is the object to save config set
 type Argument struct {
-	CheckInterval     time.Duration
-	KubeletConf       string
-	DevicePath        string
-	CPUMngState       string
-	ResReserved       map[string]string
-	KubeClientOptions ClientOptions
+	CheckInterval       time.Duration
+	KubeletConf         string
+	DevicePath          string
+	PodResourceSockPath string
+	CPUMngState         string
+	ResReserved         map[string]string
+	KubeClientOptions   ClientOptions
+
+	// EnableGetCpuIDByPodResourceList enable get cpu id by PodResourcesLister API
+	EnableGetCpuIDByPodResourceList bool
 }
 
 // NewArgument init the struct
@@ -47,6 +50,9 @@ func (args *Argument) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&args.KubeClientOptions.Master, "master", args.KubeClientOptions.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
 	fs.StringVar(&args.KubeClientOptions.KubeConfig, "kubeconfig", args.KubeClientOptions.KubeConfig, "Path to kubeconfig file with authorization and master location information.")
+
+	fs.StringVar(&args.PodResourceSockPath, "pod-resource-sock", args.PodResourceSockPath, "Path to pod-resource-sock")
+	fs.BoolVar(&args.EnableGetCpuIDByPodResourceList, "enable-pod-resource", true, "Enable get cpu id by PodResourcesLister; it is true by default")
 }
 
 // BuildConfig builds kube rest config with the given options.

--- a/pkg/args/args.go
+++ b/pkg/args/args.go
@@ -51,7 +51,7 @@ func (args *Argument) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&args.KubeClientOptions.Master, "master", args.KubeClientOptions.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig)")
 	fs.StringVar(&args.KubeClientOptions.KubeConfig, "kubeconfig", args.KubeClientOptions.KubeConfig, "Path to kubeconfig file with authorization and master location information.")
 
-	fs.StringVar(&args.PodResourceSockPath, "pod-resource-sock", args.PodResourceSockPath, "Path to pod-resource-sock")
+	fs.StringVar(&args.PodResourceSockPath, "pod-resource-sock", "/var/lib/kubelet/pod-resources", "Path to pod-resource-sock")
 	fs.BoolVar(&args.EnableGetCpuIDByPodResourceList, "enable-pod-resource", true, "Enable get cpu id by PodResourcesLister; it is true by default")
 }
 

--- a/pkg/numatopo/cpunumainfo.go
+++ b/pkg/numatopo/cpunumainfo.go
@@ -36,6 +36,8 @@ import (
 	"volcano.sh/resource-exporter/pkg/util"
 )
 
+const resourceCPU = "cpu"
+
 // CPUNumaInfo is the object to maintain the cpu information
 type CPUNumaInfo struct {
 	NUMANodes   []int
@@ -43,7 +45,8 @@ type CPUNumaInfo struct {
 	cpu2NUMA    map[int]int
 	cpuDetail   map[int]v1alpha1.CPUInfo
 
-	NUMA2FreeCpus map[int][]int
+	NUMA2FreeCpus  map[int][]int
+	podAllocations []v1alpha1.PodAllocation
 }
 
 // NewCPUNumaInfo init CPUNumaInfo struct object
@@ -58,9 +61,9 @@ func NewCPUNumaInfo() *CPUNumaInfo {
 	return numaInfo
 }
 
-// Name return function name
+// Name return the name of NumaInfo
 func (info *CPUNumaInfo) Name() string {
-	return "cpu"
+	return resourceCPU
 }
 
 func getNumaOnline(onlinePath string) []int {
@@ -100,45 +103,89 @@ func getNumaNodeCpuCap(nodePath string, nodeID int) []int {
 	return cpuList
 }
 
-func getFreeCPUList(cpuMngState string) []int {
+// getFreeCPUListAndPodAllocationsByManagerState returns a list of free (unallocated) CPU IDs and a list of pod cpu allocations by reading the cpu_manager_state file
+func getFreeCPUListAndPodAllocationsByManagerState(cpuMngState string) ([]int, []v1alpha1.PodAllocation) {
 	data, err := ioutil.ReadFile(cpuMngState)
 	if err != nil {
 		klog.Errorf("Read cpu_manager_state failed, err: %v", err)
-		return nil
+		return nil, nil
 	}
 
-	checkpoint := cpustate.NewCPUManagerCheckpoint()
-	checkpoint.UnmarshalCheckpoint(data)
+	var checkpoint cpustate.CPUManagerCheckpoint
+	if err := checkpoint.UnmarshalCheckpoint(data); err != nil {
+		klog.Errorf("Unmarshal cpu_manager_state failed, err: %v", err)
+		return nil, nil
+	}
 
 	cpuList, apiErr := util.Parse(checkpoint.DefaultCPUSet)
 	if apiErr != nil {
-		klog.Errorf("Parse cpu_manager_state failed, err: %v", err)
-		return nil
+		klog.Errorf("Parse cpu_manager_state.defaultCPUSet failed, err: %v", apiErr)
+		return nil, nil
 	}
 
-	return cpuList
+	podAllocations := make([]v1alpha1.PodAllocation, 0, len(checkpoint.Entries))
+	for podUID, containerMap := range checkpoint.Entries {
+		podAlloc := v1alpha1.PodAllocation{UID: podUID}
+		for containerName, allocatedCPUStr := range containerMap {
+			if allocatedCPUStr != "" {
+				podAlloc.ContainerAllocations = append(podAlloc.ContainerAllocations, v1alpha1.ContainerAllocation{
+					Name:        containerName,
+					Allocations: map[string]string{resourceCPU: allocatedCPUStr},
+				})
+			}
+		}
+		if len(podAlloc.ContainerAllocations) > 0 {
+			util.SortContainerAllocations(podAlloc.ContainerAllocations)
+			podAllocations = append(podAllocations, podAlloc)
+		}
+	}
+	util.SortPodAllocations(podAllocations)
+
+	klog.V(2).Infof("Collected %s PodAllocations for %d pods: %v", resourceCPU, len(podAllocations), podAllocations)
+	return cpuList, podAllocations
 }
 
-// GetFreeCPUListByPodResources returns a list of free (unallocated) CPU IDs by calling the PodResources API.
-func GetFreeCPUListByPodResources(cpu2NUMA map[int]int) []int {
+// GetFreeCPUListAndPodAllocationsByPodResources returns a list of free (unallocated) CPU IDs and a list of pod cpu allocations by calling the PodResources API.
+func GetFreeCPUListAndPodAllocationsByPodResources(cpu2NUMA map[int]int) ([]int, []v1alpha1.PodAllocation) {
 	if client == nil {
 		klog.Errorf("PodResourcesListerClient is not initialized")
-		return nil
+		return nil, nil
 	}
 
 	resp, err := client.List(context.Background(), &podresv1.ListPodResourcesRequest{})
 	if err != nil {
 		klog.Errorf("Failed to list pod resources: %v", err)
-		return nil
+		return nil, nil
 	}
 
 	// Collecting IDs of Used CPUs
 	usedCPUs := make(map[int]bool)
+	podAllocations := make([]v1alpha1.PodAllocation, 0, len(resp.PodResources))
 	for _, pod := range resp.PodResources {
+		podAlloc := v1alpha1.PodAllocation{Name: pod.Name, Namespace: pod.Namespace}
+
 		for _, container := range pod.Containers {
+			var allocatedCPUIDs []int
 			for _, cpuID := range container.CpuIds {
-				usedCPUs[int(cpuID)] = true
+				readID := int(cpuID)
+				if _, exist := cpu2NUMA[readID]; exist {
+					usedCPUs[readID] = true
+					allocatedCPUIDs = append(allocatedCPUIDs, readID)
+				}
 			}
+
+			allocatedCPUStr := util.FormatCPUs(allocatedCPUIDs)
+			if allocatedCPUStr != "" {
+				podAlloc.ContainerAllocations = append(podAlloc.ContainerAllocations, v1alpha1.ContainerAllocation{
+					Name:        container.Name,
+					Allocations: map[string]string{resourceCPU: allocatedCPUStr},
+				})
+			}
+		}
+
+		if len(podAlloc.ContainerAllocations) > 0 {
+			util.SortContainerAllocations(podAlloc.ContainerAllocations)
+			podAllocations = append(podAllocations, podAlloc)
 		}
 	}
 
@@ -151,8 +198,11 @@ func GetFreeCPUListByPodResources(cpu2NUMA map[int]int) []int {
 	}
 
 	sort.Ints(freeCPUs)
-	klog.V(3).Infof("the all cpu ids are: %v, the used CPUs are: %v, the free CPUs are: %v", cpu2NUMA, usedCPUs, freeCPUs)
-	return freeCPUs
+	util.SortPodAllocations(podAllocations)
+
+	klog.V(2).Infof("the all cpu ids are: %v, the used CPUs are: %v, the free CPUs are: %v", cpu2NUMA, usedCPUs, freeCPUs)
+	klog.V(2).Infof("Collected %s PodAllocations for %d pods: %v", resourceCPU, len(podAllocations), podAllocations)
+	return freeCPUs, podAllocations
 }
 
 func (info *CPUNumaInfo) numaCapUpdate(numaPath string) {
@@ -169,9 +219,9 @@ func (info *CPUNumaInfo) numaCapUpdate(numaPath string) {
 func (info *CPUNumaInfo) numaAllocUpdate(cpuMngState string, enableGetCpuIDByPodResourceList bool) {
 	freeCPUList := make([]int, 0)
 	if enableGetCpuIDByPodResourceList {
-		freeCPUList = GetFreeCPUListByPodResources(info.cpu2NUMA)
+		freeCPUList, info.podAllocations = GetFreeCPUListAndPodAllocationsByPodResources(info.cpu2NUMA)
 	} else {
-		freeCPUList = getFreeCPUList(cpuMngState)
+		freeCPUList, info.podAllocations = getFreeCPUListAndPodAllocationsByManagerState(cpuMngState)
 	}
 	for _, cpuid := range freeCPUList {
 		numaID := info.cpu2numa(cpuid)
@@ -274,4 +324,9 @@ func (info *CPUNumaInfo) GetResTopoDetail() interface{} {
 	}
 
 	return allCPUTopoInfo
+}
+
+// GetPodAllocations returns the pod allocation info
+func (info *CPUNumaInfo) GetPodAllocations() []v1alpha1.PodAllocation {
+	return info.podAllocations
 }

--- a/pkg/numatopo/cpunumainfo.go
+++ b/pkg/numatopo/cpunumainfo.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"sort"
 	"strconv"
+	"time"
 
 	"k8s.io/klog/v2"
 	podresv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
@@ -104,23 +105,20 @@ func getNumaNodeCpuCap(nodePath string, nodeID int) []int {
 }
 
 // getFreeCPUListAndPodAllocationsByManagerState returns a list of free (unallocated) CPU IDs and a list of pod cpu allocations by reading the cpu_manager_state file
-func getFreeCPUListAndPodAllocationsByManagerState(cpuMngState string) ([]int, []v1alpha1.PodAllocation) {
+func getFreeCPUListAndPodAllocationsByManagerState(cpuMngState string) ([]int, []v1alpha1.PodAllocation, error) {
 	data, err := ioutil.ReadFile(cpuMngState)
 	if err != nil {
-		klog.Errorf("Read cpu_manager_state failed, err: %v", err)
-		return nil, nil
+		return nil, nil, fmt.Errorf("read cpu_manager_state failed, err: %w", err)
 	}
 
 	var checkpoint cpustate.CPUManagerCheckpoint
 	if err := checkpoint.UnmarshalCheckpoint(data); err != nil {
-		klog.Errorf("Unmarshal cpu_manager_state failed, err: %v", err)
-		return nil, nil
+		return nil, nil, fmt.Errorf("unmarshal cpu_manager_state failed, err: %w", err)
 	}
 
 	cpuList, apiErr := util.Parse(checkpoint.DefaultCPUSet)
 	if apiErr != nil {
-		klog.Errorf("Parse cpu_manager_state.defaultCPUSet failed, err: %v", apiErr)
-		return nil, nil
+		return nil, nil, fmt.Errorf("parse cpu_manager_state.defaultCPUSet failed, err: %w", apiErr)
 	}
 
 	podAllocations := make([]v1alpha1.PodAllocation, 0, len(checkpoint.Entries))
@@ -142,29 +140,40 @@ func getFreeCPUListAndPodAllocationsByManagerState(cpuMngState string) ([]int, [
 	util.SortPodAllocations(podAllocations)
 
 	klog.V(2).Infof("Collected %s PodAllocations for %d pods: %v", resourceCPU, len(podAllocations), podAllocations)
-	return cpuList, podAllocations
+	return cpuList, podAllocations, nil
 }
 
 // GetFreeCPUListAndPodAllocationsByPodResources returns a list of free (unallocated) CPU IDs and a list of pod cpu allocations by calling the PodResources API.
-func GetFreeCPUListAndPodAllocationsByPodResources(cpu2NUMA map[int]int) ([]int, []v1alpha1.PodAllocation) {
+func GetFreeCPUListAndPodAllocationsByPodResources(cpu2NUMA map[int]int) ([]int, []v1alpha1.PodAllocation, error) {
 	if client == nil {
-		klog.Errorf("PodResourcesListerClient is not initialized")
-		return nil, nil
+		return nil, nil, fmt.Errorf("PodResourcesListerClient is not initialized")
 	}
 
-	resp, err := client.List(context.Background(), &podresv1.ListPodResourcesRequest{})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	resp, err := client.List(ctx, &podresv1.ListPodResourcesRequest{})
 	if err != nil {
-		klog.Errorf("Failed to list pod resources: %v", err)
-		return nil, nil
+		return nil, nil, fmt.Errorf("failed to list pod resources, err: %w", err)
+	}
+
+	if resp == nil {
+		return nil, nil, fmt.Errorf("received nil response from PodResourcesListerClient")
 	}
 
 	// Collecting IDs of Used CPUs
 	usedCPUs := make(map[int]bool)
 	podAllocations := make([]v1alpha1.PodAllocation, 0, len(resp.PodResources))
 	for _, pod := range resp.PodResources {
+		if pod == nil {
+			continue
+		}
 		podAlloc := v1alpha1.PodAllocation{Name: pod.Name, Namespace: pod.Namespace}
 
 		for _, container := range pod.Containers {
+			if container == nil {
+				continue
+			}
 			var allocatedCPUIDs []int
 			for _, cpuID := range container.CpuIds {
 				readID := int(cpuID)
@@ -202,7 +211,7 @@ func GetFreeCPUListAndPodAllocationsByPodResources(cpu2NUMA map[int]int) ([]int,
 
 	klog.V(2).Infof("the all cpu ids are: %v, the used CPUs are: %v, the free CPUs are: %v", cpu2NUMA, usedCPUs, freeCPUs)
 	klog.V(2).Infof("Collected %s PodAllocations for %d pods: %v", resourceCPU, len(podAllocations), podAllocations)
-	return freeCPUs, podAllocations
+	return freeCPUs, podAllocations, nil
 }
 
 func (info *CPUNumaInfo) numaCapUpdate(numaPath string) {
@@ -216,17 +225,27 @@ func (info *CPUNumaInfo) numaCapUpdate(numaPath string) {
 	}
 }
 
-func (info *CPUNumaInfo) numaAllocUpdate(cpuMngState string, enableGetCpuIDByPodResourceList bool) {
+func (info *CPUNumaInfo) numaAllocUpdate(cpuMngState string, enableGetCpuIDByPodResourceList bool) error {
 	freeCPUList := make([]int, 0)
+	var err error
 	if enableGetCpuIDByPodResourceList {
-		freeCPUList, info.podAllocations = GetFreeCPUListAndPodAllocationsByPodResources(info.cpu2NUMA)
+		freeCPUList, info.podAllocations, err = GetFreeCPUListAndPodAllocationsByPodResources(info.cpu2NUMA)
 	} else {
-		freeCPUList, info.podAllocations = getFreeCPUListAndPodAllocationsByManagerState(cpuMngState)
+		freeCPUList, info.podAllocations, err = getFreeCPUListAndPodAllocationsByManagerState(cpuMngState)
 	}
+	if err != nil {
+		// Preserve the previous valid state by aborting the update on failure;
+		// otherwise an empty free CPU list would overwrite the allocatable CPUs
+		// in the custom resource.
+		return err
+	}
+
 	for _, cpuid := range freeCPUList {
 		numaID := info.cpu2numa(cpuid)
 		info.NUMA2FreeCpus[numaID] = append(info.NUMA2FreeCpus[numaID], cpuid)
 	}
+
+	return nil
 }
 
 // Update returns the latest cpu numa info
@@ -236,7 +255,10 @@ func (info *CPUNumaInfo) Update(opt *args.Argument) NumaInfo {
 	newInfo := NewCPUNumaInfo()
 	newInfo.NUMANodes = getNumaOnline(filepath.Join(cpuNumaBasePath, "online"))
 	newInfo.numaCapUpdate(cpuNumaBasePath)
-	newInfo.numaAllocUpdate(opt.CPUMngState, opt.EnableGetCpuIDByPodResourceList)
+	if err := newInfo.numaAllocUpdate(opt.CPUMngState, opt.EnableGetCpuIDByPodResourceList); err != nil {
+		klog.Errorf("Failed to update NUMA allocation: %v", err)
+		return nil
+	}
 	newInfo.cpuDetail = newInfo.getAllCPUTopoInfo(opt.DevicePath)
 	if !reflect.DeepEqual(newInfo, info) {
 		return newInfo

--- a/pkg/numatopo/cpunumainfo_test.go
+++ b/pkg/numatopo/cpunumainfo_test.go
@@ -1,0 +1,532 @@
+/*
+Copyright 2021 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package numatopo
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"google.golang.org/grpc"
+	podresv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
+	cpustate "k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
+)
+
+// ---------------------------------------------------------------------------
+// helpers for the cpu_manager_state backend
+// ---------------------------------------------------------------------------
+
+func writeCheckpointFile(t *testing.T, path string, cp *cpustate.CPUManagerCheckpoint) {
+	t.Helper()
+	blob, err := cp.MarshalCheckpoint()
+	if err != nil {
+		t.Fatalf("marshal checkpoint: %v", err)
+	}
+	if err := os.WriteFile(path, blob, 0o600); err != nil {
+		t.Fatalf("write checkpoint file: %v", err)
+	}
+}
+
+func newCheckpoint(defaultCPUSet string, entries map[string]map[string]string) *cpustate.CPUManagerCheckpoint {
+	cp := cpustate.NewCPUManagerCheckpoint()
+	cp.PolicyName = "static"
+	cp.DefaultCPUSet = defaultCPUSet
+	for podUID, containers := range entries {
+		if cp.Entries[podUID] == nil {
+			cp.Entries[podUID] = make(map[string]string)
+		}
+		for cname, val := range containers {
+			cp.Entries[podUID][cname] = val
+		}
+	}
+	return cp
+}
+
+// ---------------------------------------------------------------------------
+// getFreeCPUListAndPodAllocationsByManagerState
+// ---------------------------------------------------------------------------
+
+func TestGetFreeCPUListAndPodAllocationsByManagerState(t *testing.T) {
+	t.Run("normal: returns free cpus and sorted pod allocations", func(t *testing.T) {
+		dir := t.TempDir()
+		statePath := filepath.Join(dir, "cpu_manager_state")
+		writeCheckpointFile(t, statePath, newCheckpoint("4-7", map[string]map[string]string{
+			"uid-b": {"c1": "0-1", "c2": ""},
+			"uid-a": {"c1": "2-3"},
+		}))
+
+		freeCpus, podAllocs, err := getFreeCPUListAndPodAllocationsByManagerState(statePath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := []int{4, 5, 6, 7}; !reflect.DeepEqual(freeCpus, want) {
+			t.Fatalf("freeCpus: expected %v, got %v", want, freeCpus)
+		}
+
+		if len(podAllocs) != 2 {
+			t.Fatalf("expected 2 pod allocations, got %d", len(podAllocs))
+		}
+		// Sorted by UID
+		if podAllocs[0].UID != "uid-a" || podAllocs[1].UID != "uid-b" {
+			t.Fatalf("unexpected pod order: %v %v", podAllocs[0].UID, podAllocs[1].UID)
+		}
+		// containers with empty cpu string are filtered out
+		if len(podAllocs[1].ContainerAllocations) != 1 {
+			t.Fatalf("expected 1 container for uid-b (empty one dropped), got %d",
+				len(podAllocs[1].ContainerAllocations))
+		}
+		if podAllocs[1].ContainerAllocations[0].Name != "c1" {
+			t.Fatalf("expected c1, got %q", podAllocs[1].ContainerAllocations[0].Name)
+		}
+		if got := podAllocs[1].ContainerAllocations[0].Allocations[resourceCPU]; got != "0-1" {
+			t.Fatalf("expected \"0-1\", got %q", got)
+		}
+	})
+
+	t.Run("containers within a pod are sorted by name", func(t *testing.T) {
+		dir := t.TempDir()
+		statePath := filepath.Join(dir, "cpu_manager_state")
+		writeCheckpointFile(t, statePath, newCheckpoint("0", map[string]map[string]string{
+			"uid-x": {"zContainer": "1", "aContainer": "2", "mContainer": "3"},
+		}))
+
+		_, podAllocs, err := getFreeCPUListAndPodAllocationsByManagerState(statePath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(podAllocs) != 1 || len(podAllocs[0].ContainerAllocations) != 3 {
+			t.Fatalf("unexpected allocation shape: %+v", podAllocs)
+		}
+		got := []string{
+			podAllocs[0].ContainerAllocations[0].Name,
+			podAllocs[0].ContainerAllocations[1].Name,
+			podAllocs[0].ContainerAllocations[2].Name,
+		}
+		want := []string{"aContainer", "mContainer", "zContainer"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	})
+
+	t.Run("no entries: empty pod allocations, free CPU = defaultCPUSet", func(t *testing.T) {
+		dir := t.TempDir()
+		statePath := filepath.Join(dir, "cpu_manager_state")
+		writeCheckpointFile(t, statePath, newCheckpoint("0-3", nil))
+
+		freeCpus, podAllocs, err := getFreeCPUListAndPodAllocationsByManagerState(statePath)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := []int{0, 1, 2, 3}; !reflect.DeepEqual(freeCpus, want) {
+			t.Fatalf("expected %v, got %v", want, freeCpus)
+		}
+		if len(podAllocs) != 0 {
+			t.Fatalf("expected 0 pod allocations, got %d", len(podAllocs))
+		}
+	})
+
+	t.Run("missing file: returns error", func(t *testing.T) {
+		_, _, err := getFreeCPUListAndPodAllocationsByManagerState(filepath.Join(t.TempDir(), "nope"))
+		if err == nil {
+			t.Fatalf("expected error for missing file")
+		}
+	})
+
+	t.Run("invalid JSON: returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		statePath := filepath.Join(dir, "cpu_manager_state")
+		if err := os.WriteFile(statePath, []byte("{not-json"), 0o600); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+		_, _, err := getFreeCPUListAndPodAllocationsByManagerState(statePath)
+		if err == nil {
+			t.Fatalf("expected error for invalid JSON")
+		}
+	})
+
+	t.Run("invalid defaultCPUSet: returns error", func(t *testing.T) {
+		dir := t.TempDir()
+		statePath := filepath.Join(dir, "cpu_manager_state")
+		writeCheckpointFile(t, statePath, newCheckpoint("abc", nil))
+		_, _, err := getFreeCPUListAndPodAllocationsByManagerState(statePath)
+		if err == nil {
+			t.Fatalf("expected error for invalid defaultCPUSet")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// numaAllocUpdate
+// ---------------------------------------------------------------------------
+
+// newInfoWithNUMA builds a CPUNumaInfo whose cpu2NUMA map is populated and
+// whose NUMA2FreeCpus map is initialized. NUMA2FreeCpus is seeded with the
+// given prior values so the "failure must not overwrite" contract can be
+// exercised.
+func newInfoWithNUMA(cpu2NUMA map[int]int, priorFreeCpus map[int][]int) *CPUNumaInfo {
+	info := NewCPUNumaInfo()
+	info.cpu2NUMA = cpu2NUMA
+	for numaID, cpus := range priorFreeCpus {
+		info.NUMA2FreeCpus[numaID] = append([]int(nil), cpus...)
+	}
+	return info
+}
+
+func TestNumaAllocUpdate(t *testing.T) {
+	cpu2NUMA := map[int]int{0: 0, 1: 0, 2: 0, 3: 1, 4: 1}
+
+	t.Run("manager_state backend success: buckets free cpus per NUMA and records allocations", func(t *testing.T) {
+		dir := t.TempDir()
+		statePath := filepath.Join(dir, "cpu_manager_state")
+		// defaultCPUSet = free = {0,1,3}; entries use {2},{4}
+		writeCheckpointFile(t, statePath, newCheckpoint("0-1,3", map[string]map[string]string{
+			"uid-a": {"c0": "2"},
+			"uid-b": {"c0": "4"},
+		}))
+
+		info := newInfoWithNUMA(cpu2NUMA, nil)
+		err := info.numaAllocUpdate(statePath, false)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Free CPUs 0,1 on NUMA 0; CPU 3 on NUMA 1. Order is insertion-based
+		// (0,1 from the defaultCPUSet parse, 3 last), so we compare as sets.
+		if got, want := info.NUMA2FreeCpus[0], []int{0, 1}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("NUMA0 free: expected %v, got %v", want, got)
+		}
+		if got, want := info.NUMA2FreeCpus[1], []int{3}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("NUMA1 free: expected %v, got %v", want, got)
+		}
+		if len(info.podAllocations) != 2 {
+			t.Fatalf("expected 2 pod allocations, got %d", len(info.podAllocations))
+		}
+	})
+
+	t.Run("manager_state backend failure: does not overwrite prior NUMA2FreeCpus", func(t *testing.T) {
+		// Missing file -> backend returns error. Prior free state must survive.
+		info := newInfoWithNUMA(cpu2NUMA, map[int][]int{
+			0: {0, 1},
+			1: {3, 4},
+		})
+		err := info.numaAllocUpdate(filepath.Join(t.TempDir(), "missing"), false)
+		if err == nil {
+			t.Fatalf("expected error from manager_state backend")
+		}
+		if got, want := info.NUMA2FreeCpus[0], []int{0, 1}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("NUMA0 free must be preserved on failure: expected %v, got %v", want, got)
+		}
+		if got, want := info.NUMA2FreeCpus[1], []int{3, 4}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("NUMA1 free must be preserved on failure: expected %v, got %v", want, got)
+		}
+		if info.podAllocations != nil {
+			t.Fatalf("podAllocations must remain nil on failure, got %v", info.podAllocations)
+		}
+	})
+
+	t.Run("podresources backend success: buckets free cpus per NUMA", func(t *testing.T) {
+		resp := &podresv1.ListPodResourcesResponse{
+			PodResources: []*podresv1.PodResources{
+				{Name: "pod-a", Namespace: "ns", Containers: []*podresv1.ContainerResources{
+					{Name: "c0", CpuIds: []int64{0, 2}}, // uses NUMA0 cpus 0,2 -> free on NUMA0: {1}
+				}},
+				{Name: "pod-b", Namespace: "ns", Containers: []*podresv1.ContainerResources{
+					{Name: "c0", CpuIds: []int64{4}}, // uses NUMA1 cpu 4 -> free on NUMA1: {3}
+				}},
+			},
+		}
+		withClient(t, &fakePodResourcesClient{resp: resp})
+
+		info := newInfoWithNUMA(cpu2NUMA, nil)
+		if err := info.numaAllocUpdate("", true); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got, want := info.NUMA2FreeCpus[0], []int{1}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("NUMA0 free: expected %v, got %v", want, got)
+		}
+		if got, want := info.NUMA2FreeCpus[1], []int{3}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("NUMA1 free: expected %v, got %v", want, got)
+		}
+		if len(info.podAllocations) != 2 {
+			t.Fatalf("expected 2 pod allocations, got %d", len(info.podAllocations))
+		}
+	})
+
+	t.Run("podresources backend failure: does not overwrite prior NUMA2FreeCpus", func(t *testing.T) {
+		withClient(t, &fakePodResourcesClient{err: errors.New("rpc broken")})
+
+		info := newInfoWithNUMA(cpu2NUMA, map[int][]int{
+			0: {0, 1},
+			1: {3, 4},
+		})
+		err := info.numaAllocUpdate("", true)
+		if err == nil {
+			t.Fatalf("expected error from podresources backend")
+		}
+		if got, want := info.NUMA2FreeCpus[0], []int{0, 1}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("NUMA0 free must be preserved on failure: expected %v, got %v", want, got)
+		}
+		if got, want := info.NUMA2FreeCpus[1], []int{3, 4}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("NUMA1 free must be preserved on failure: expected %v, got %v", want, got)
+		}
+	})
+
+	t.Run("podresources nil client: failure preserves prior state", func(t *testing.T) {
+		withClient(t, nil)
+		info := newInfoWithNUMA(cpu2NUMA, map[int][]int{0: {0}})
+		if err := info.numaAllocUpdate("", true); err == nil {
+			t.Fatalf("expected error when client is nil")
+		}
+		if got, want := info.NUMA2FreeCpus[0], []int{0}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("NUMA0 free must be preserved: expected %v, got %v", want, got)
+		}
+	})
+
+	t.Run("empty freeCPUList clears NUMA2FreeCpus bucket when no prior state", func(t *testing.T) {
+		// Manager-state with defaultCPUSet that parses to nothing is hard (Parse is
+		// lenient), so use the podresources path with no pods: all CPUs free.
+		withClient(t, &fakePodResourcesClient{resp: &podresv1.ListPodResourcesResponse{}})
+
+		info := newInfoWithNUMA(cpu2NUMA, nil)
+		if err := info.numaAllocUpdate("", true); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// All CPUs free -> NUMA0 {0,1,2}, NUMA1 {3,4}. Both buckets populated.
+		if got, want := info.NUMA2FreeCpus[0], []int{0, 1, 2}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("NUMA0 free: expected %v, got %v", want, got)
+		}
+		if got, want := info.NUMA2FreeCpus[1], []int{3, 4}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("NUMA1 free: expected %v, got %v", want, got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// helpers for the podresources backend
+// ---------------------------------------------------------------------------
+
+// fakePodResourcesClient is a minimal PodResourcesListerClient fake that only
+// implements List. Get/GetAllocatableResources are not exercised by the
+// function under test.
+type fakePodResourcesClient struct {
+	resp *podresv1.ListPodResourcesResponse
+	err  error
+}
+
+func (f *fakePodResourcesClient) List(ctx context.Context, _ *podresv1.ListPodResourcesRequest, _ ...grpc.CallOption) (*podresv1.ListPodResourcesResponse, error) {
+	return f.resp, f.err
+}
+
+func (f *fakePodResourcesClient) GetAllocatableResources(ctx context.Context, _ *podresv1.AllocatableResourcesRequest, _ ...grpc.CallOption) (*podresv1.AllocatableResourcesResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (f *fakePodResourcesClient) Get(ctx context.Context, _ *podresv1.GetPodResourcesRequest, _ ...grpc.CallOption) (*podresv1.GetPodResourcesResponse, error) {
+	return nil, errors.New("not implemented")
+}
+
+// withClient swaps the package-level client var for the duration of a test and
+// restores the previous value on cleanup.
+func withClient(t *testing.T, c podresv1.PodResourcesListerClient) {
+	t.Helper()
+	prev := client
+	client = c
+	t.Cleanup(func() { client = prev })
+}
+
+// Sanity guard: the fake must satisfy the PodResourcesListerClient interface.
+var _ podresv1.PodResourcesListerClient = (*fakePodResourcesClient)(nil)
+
+// ---------------------------------------------------------------------------
+// GetFreeCPUListAndPodAllocationsByPodResources
+// ---------------------------------------------------------------------------
+
+func TestGetFreeCPUListAndPodAllocationsByPodResources(t *testing.T) {
+	// NUMA map: cpus 0-3 on NUMA 0, cpus 4-7 on NUMA 1.
+	cpu2NUMA := map[int]int{0: 0, 1: 0, 2: 0, 3: 0, 4: 1, 5: 1, 6: 1, 7: 1}
+
+	t.Run("nil client returns error", func(t *testing.T) {
+		withClient(t, nil)
+		_, _, err := GetFreeCPUListAndPodAllocationsByPodResources(cpu2NUMA)
+		if err == nil {
+			t.Fatalf("expected error when client is nil")
+		}
+	})
+
+	t.Run("List error propagates", func(t *testing.T) {
+		withClient(t, &fakePodResourcesClient{err: errors.New("rpc broken")})
+		_, _, err := GetFreeCPUListAndPodAllocationsByPodResources(cpu2NUMA)
+		if err == nil {
+			t.Fatalf("expected error when List fails")
+		}
+	})
+
+	t.Run("nil response returns error", func(t *testing.T) {
+		withClient(t, &fakePodResourcesClient{resp: nil})
+		_, _, err := GetFreeCPUListAndPodAllocationsByPodResources(cpu2NUMA)
+		if err == nil {
+			t.Fatalf("expected error when response is nil")
+		}
+	})
+
+	t.Run("normal: free cpus sorted, allocations sorted, unknown cpus ignored", func(t *testing.T) {
+		resp := &podresv1.ListPodResourcesResponse{
+			PodResources: []*podresv1.PodResources{
+				{
+					Name:      "pod-b",
+					Namespace: "ns",
+					Containers: []*podresv1.ContainerResources{
+						{Name: "c1", CpuIds: []int64{0, 1}},
+						{Name: "c0", CpuIds: []int64{2}},
+					},
+				},
+				{
+					Name:      "pod-a",
+					Namespace: "ns",
+					Containers: []*podresv1.ContainerResources{
+						{Name: "c1", CpuIds: []int64{4, 5}},
+						// CPU 99 is outside cpu2NUMA and must be ignored.
+						{Name: "c2", CpuIds: []int64{99}},
+					},
+				},
+			},
+		}
+		withClient(t, &fakePodResourcesClient{resp: resp})
+
+		freeCpus, podAllocs, err := GetFreeCPUListAndPodAllocationsByPodResources(cpu2NUMA)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Used CPUs: 0,1,2,4,5 -> Free: 3,6,7
+		if want := []int{3, 6, 7}; !reflect.DeepEqual(freeCpus, want) {
+			t.Fatalf("freeCpus: expected %v, got %v", want, freeCpus)
+		}
+
+		// Sorted by namespace then name.
+		if len(podAllocs) != 2 {
+			t.Fatalf("expected 2 pod allocations, got %d", len(podAllocs))
+		}
+		if podAllocs[0].Name != "pod-a" || podAllocs[1].Name != "pod-b" {
+			t.Fatalf("unexpected pod order: %q %q", podAllocs[0].Name, podAllocs[1].Name)
+		}
+
+		// pod-b: containers sorted by name (c0, c1). FormatCPUs applied.
+		b := podAllocs[1]
+		if len(b.ContainerAllocations) != 2 {
+			t.Fatalf("expected 2 containers, got %d", len(b.ContainerAllocations))
+		}
+		if b.ContainerAllocations[0].Name != "c0" || b.ContainerAllocations[1].Name != "c1" {
+			t.Fatalf("containers not sorted: %q %q",
+				b.ContainerAllocations[0].Name, b.ContainerAllocations[1].Name)
+		}
+		if got := b.ContainerAllocations[1].Allocations[resourceCPU]; got != "0-1" {
+			t.Fatalf("expected \"0-1\", got %q", got)
+		}
+
+		// pod-a: c2 had only unknown cpu (99), so it must be dropped (no container allocation).
+		a := podAllocs[0]
+		if len(a.ContainerAllocations) != 1 {
+			t.Fatalf("expected 1 container (c2 dropped), got %d", len(a.ContainerAllocations))
+		}
+		if a.ContainerAllocations[0].Name != "c1" {
+			t.Fatalf("expected c1, got %q", a.ContainerAllocations[0].Name)
+		}
+		if got := a.ContainerAllocations[0].Allocations[resourceCPU]; got != "4-5" {
+			t.Fatalf("expected \"4-5\", got %q", got)
+		}
+	})
+
+	t.Run("nil pod and nil container are skipped", func(t *testing.T) {
+		resp := &podresv1.ListPodResourcesResponse{
+			PodResources: []*podresv1.PodResources{
+				nil,
+				{
+					Name:      "pod-a",
+					Namespace: "ns",
+					Containers: []*podresv1.ContainerResources{
+						nil,
+						{Name: "c0", CpuIds: []int64{0}},
+					},
+				},
+			},
+		}
+		withClient(t, &fakePodResourcesClient{resp: resp})
+
+		freeCpus, podAllocs, err := GetFreeCPUListAndPodAllocationsByPodResources(cpu2NUMA)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := []int{1, 2, 3, 4, 5, 6, 7}; !reflect.DeepEqual(freeCpus, want) {
+			t.Fatalf("freeCpus: expected %v, got %v", want, freeCpus)
+		}
+		if len(podAllocs) != 1 || podAllocs[0].Name != "pod-a" {
+			t.Fatalf("unexpected pod allocations: %+v", podAllocs)
+		}
+		if len(podAllocs[0].ContainerAllocations) != 1 {
+			t.Fatalf("expected 1 container (nil dropped), got %d", len(podAllocs[0].ContainerAllocations))
+		}
+	})
+
+	t.Run("empty cpu2NUMA: no free cpus, no allocations", func(t *testing.T) {
+		resp := &podresv1.ListPodResourcesResponse{
+			PodResources: []*podresv1.PodResources{
+				{Name: "pod-a", Namespace: "ns", Containers: []*podresv1.ContainerResources{
+					{Name: "c0", CpuIds: []int64{0, 1, 2}},
+				}},
+			},
+		}
+		withClient(t, &fakePodResourcesClient{resp: resp})
+
+		freeCpus, podAllocs, err := GetFreeCPUListAndPodAllocationsByPodResources(map[int]int{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(freeCpus) != 0 {
+			t.Fatalf("expected 0 free cpus, got %v", freeCpus)
+		}
+		// All CPUs are outside cpu2NUMA, so no container allocation recorded.
+		if len(podAllocs) != 0 {
+			t.Fatalf("expected 0 pod allocations, got %d", len(podAllocs))
+		}
+	})
+
+	t.Run("all cpus allocated: free cpus empty", func(t *testing.T) {
+		resp := &podresv1.ListPodResourcesResponse{
+			PodResources: []*podresv1.PodResources{
+				{Name: "pod-a", Namespace: "ns", Containers: []*podresv1.ContainerResources{
+					{Name: "c0", CpuIds: []int64{0, 1, 2, 3, 4, 5, 6, 7}},
+				}},
+			},
+		}
+		withClient(t, &fakePodResourcesClient{resp: resp})
+
+		freeCpus, _, err := GetFreeCPUListAndPodAllocationsByPodResources(cpu2NUMA)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(freeCpus) != 0 {
+			t.Fatalf("expected 0 free cpus, got %v", freeCpus)
+		}
+	})
+}
+
+// Ensure sort import stays referenced if future helpers use it directly.
+var _ = sort.Slice

--- a/pkg/numatopo/cputopo.go
+++ b/pkg/numatopo/cputopo.go
@@ -17,13 +17,16 @@ limitations under the License.
 package numatopo
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strconv"
 
 	"k8s.io/klog/v2"
+	podresv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
 	cpustate "k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
 	"k8s.io/utils/cpuset"
 
@@ -116,6 +119,42 @@ func getFreeCPUList(cpuMngState string) []int {
 	return cpuList
 }
 
+// GetFreeCPUListByPodResources returns a list of free (unallocated) CPU IDs by calling the PodResources API.
+func GetFreeCPUListByPodResources(cpu2NUMA map[int]int) []int {
+	if client == nil {
+		klog.Errorf("PodResourcesListerClient is not initialized")
+		return nil
+	}
+
+	resp, err := client.List(context.Background(), &podresv1.ListPodResourcesRequest{})
+	if err != nil {
+		klog.Errorf("Failed to list pod resources: %v", err)
+		return nil
+	}
+
+	// Collecting IDs of Used CPUs
+	usedCPUs := make(map[int]bool)
+	for _, pod := range resp.PodResources {
+		for _, container := range pod.Containers {
+			for _, cpuID := range container.CpuIds {
+				usedCPUs[int(cpuID)] = true
+			}
+		}
+	}
+
+	// Traverse cpu2NUMA to find the IDs of unused CPUs
+	var freeCPUs []int
+	for cpuID := range cpu2NUMA {
+		if !usedCPUs[cpuID] {
+			freeCPUs = append(freeCPUs, cpuID)
+		}
+	}
+
+	sort.Ints(freeCPUs)
+	klog.V(3).Infof("the all cpu ids are: %v, the used CPUs are: %v, the free CPUs are: %v", cpu2NUMA, usedCPUs, freeCPUs)
+	return freeCPUs
+}
+
 func (info *CPUNumaInfo) numaCapUpdate(numaPath string) {
 	for _, node := range info.NUMANodes {
 		cpuList := getNumaNodeCpuCap(numaPath, node)
@@ -127,8 +166,13 @@ func (info *CPUNumaInfo) numaCapUpdate(numaPath string) {
 	}
 }
 
-func (info *CPUNumaInfo) numaAllocUpdate(cpuMngState string) {
-	freeCPUList := getFreeCPUList(cpuMngState)
+func (info *CPUNumaInfo) numaAllocUpdate(cpuMngState string, enableGetCpuIDByPodResourceList bool) {
+	freeCPUList := make([]int, 0)
+	if enableGetCpuIDByPodResourceList {
+		freeCPUList = GetFreeCPUListByPodResources(info.cpu2NUMA)
+	} else {
+		freeCPUList = getFreeCPUList(cpuMngState)
+	}
 	for _, cpuid := range freeCPUList {
 		numaID := info.cpu2numa(cpuid)
 		info.NUMA2FreeCpus[numaID] = append(info.NUMA2FreeCpus[numaID], cpuid)
@@ -142,7 +186,7 @@ func (info *CPUNumaInfo) Update(opt *args.Argument) NumaInfo {
 	newInfo := NewCPUNumaInfo()
 	newInfo.NUMANodes = getNumaOnline(filepath.Join(cpuNumaBasePath, "online"))
 	newInfo.numaCapUpdate(cpuNumaBasePath)
-	newInfo.numaAllocUpdate(opt.CPUMngState)
+	newInfo.numaAllocUpdate(opt.CPUMngState, opt.EnableGetCpuIDByPodResourceList)
 	newInfo.cpuDetail = newInfo.getAllCPUTopoInfo(opt.DevicePath)
 	if !reflect.DeepEqual(newInfo, info) {
 		return newInfo

--- a/pkg/numatopo/framework.go
+++ b/pkg/numatopo/framework.go
@@ -73,6 +73,20 @@ func GetCpusDetail() map[string]v1alpha1.CPUInfo {
 	return nil
 }
 
+// GetPodAllocations returns the pod resource allocation info
+func GetPodAllocations() []v1alpha1.PodAllocation {
+	var podAllocations []v1alpha1.PodAllocation
+
+	for _, info := range numaMap {
+		pas := info.GetPodAllocations()
+		if len(pas) > 0 {
+			podAllocations = append(podAllocations, pas...)
+		}
+	}
+
+	return podAllocations
+}
+
 func init() {
 	RegisterNumaType(NewCPUNumaInfo())
 }

--- a/pkg/numatopo/interface.go
+++ b/pkg/numatopo/interface.go
@@ -22,10 +22,11 @@ import (
 	"volcano.sh/resource-exporter/pkg/args"
 )
 
-// NumaInfo is the interface of resource topology data
+// NumaInfo is the interface of numa resource topology and per-pod/container allocation data
 type NumaInfo interface {
 	Name() string
 	Update(opt *args.Argument) NumaInfo
 	GetResourceInfoMap() v1alpha1.ResourceInfo
 	GetResTopoDetail() interface{}
+	GetPodAllocations() []v1alpha1.PodAllocation
 }

--- a/pkg/numatopo/kubeletconfig.go
+++ b/pkg/numatopo/kubeletconfig.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 
 	machineinfov1 "github.com/google/cadvisor/info/v1"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
@@ -32,6 +31,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"volcano.sh/apis/pkg/apis/nodeinfo/v1alpha1"
+
 	"volcano.sh/resource-exporter/pkg/machineinfo"
 	"volcano.sh/resource-exporter/pkg/util"
 )

--- a/pkg/numatopo/podresourcesclient.go
+++ b/pkg/numatopo/podresourcesclient.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package numatopo
 
 import (

--- a/pkg/numatopo/podresourcesclient.go
+++ b/pkg/numatopo/podresourcesclient.go
@@ -1,0 +1,33 @@
+package numatopo
+
+import (
+	"path/filepath"
+	"time"
+
+	"google.golang.org/grpc"
+	podresv1 "k8s.io/kubelet/pkg/apis/podresources/v1"
+	"k8s.io/kubernetes/pkg/kubelet/apis/podresources"
+)
+
+const (
+	defaultConnectionTimeout = 2 * time.Second
+	defaultMaxSize           = 1024 * 1024 * 16
+)
+
+var (
+	client podresv1.PodResourcesListerClient
+	conn   *grpc.ClientConn
+)
+
+func InitPodResourcesClient(sockDir string) error {
+	sockPath := filepath.Join(sockDir, "kubelet.sock")
+	var err error
+	client, conn, err = podresources.GetV1Client("unix://"+sockPath, defaultConnectionTimeout, defaultMaxSize)
+	return err
+}
+
+func ClosePodResourcesClient() {
+	if conn != nil {
+		conn.Close()
+	}
+}

--- a/pkg/numatopo/reservation_test.go
+++ b/pkg/numatopo/reservation_test.go
@@ -22,12 +22,12 @@ import (
 	"os"
 	"testing"
 
+	machineinfov1 "github.com/google/cadvisor/info/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
 
-	machineinfov1 "github.com/google/cadvisor/info/v1"
 	nodeinfov1alpha1 "volcano.sh/apis/pkg/apis/nodeinfo/v1alpha1"
 	"volcano.sh/apis/pkg/client/clientset/versioned/fake"
 )

--- a/pkg/numatopo/update.go
+++ b/pkg/numatopo/update.go
@@ -68,10 +68,11 @@ func CreateOrUpdateNumatopo(client versioned.Interface, cached *v1alpha1.Numatop
 				Name: hostname,
 			},
 			Spec: v1alpha1.NumatopoSpec{
-				Policies:    GetPolicy(),
-				ResReserved: GetResReserved(),
-				NumaResMap:  GetAllResAllocatableInfo(),
-				CPUDetail:   GetCpusDetail(),
+				Policies:       GetPolicy(),
+				ResReserved:    GetResReserved(),
+				NumaResMap:     GetAllResAllocatableInfo(),
+				CPUDetail:      GetCpusDetail(),
+				PodAllocations: GetPodAllocations(),
 			},
 		}
 
@@ -92,26 +93,27 @@ func CreateOrUpdateNumatopo(client versioned.Interface, cached *v1alpha1.Numatop
 			klog.V(4).Infof("Created Numatopo for node %s successfully", hostname)
 			return
 		}
-	}
-
-	// Resource exists in cache, update it
-	numaInfo := cached.DeepCopy()
-	numaInfo.Spec = v1alpha1.NumatopoSpec{
-		Policies:    GetPolicy(),
-		ResReserved: GetResReserved(),
-		NumaResMap:  GetAllResAllocatableInfo(),
-		CPUDetail:   GetCpusDetail(),
-	}
-	if numaInfo.Annotations == nil {
-		numaInfo.Annotations = make(map[string]string)
-	}
-	// use to trigger CR numa update
-	numaInfo.Annotations["timestamp"] = fmt.Sprint(time.Now().Unix())
-
-	_, err := client.NodeinfoV1alpha1().Numatopologies().Update(context.TODO(), numaInfo, metav1.UpdateOptions{})
-	if err != nil {
-		klog.Errorf("Update Numatopo for node %s failed, err=%v", hostname, err)
 	} else {
-		klog.V(4).Infof("Updated Numatopo for node %s successfully", hostname)
+		// Resource exists in cache, update it
+		numaInfo := cached.DeepCopy()
+		numaInfo.Spec = v1alpha1.NumatopoSpec{
+			Policies:       GetPolicy(),
+			ResReserved:    GetResReserved(),
+			NumaResMap:     GetAllResAllocatableInfo(),
+			CPUDetail:      GetCpusDetail(),
+			PodAllocations: GetPodAllocations(),
+		}
+		if numaInfo.Annotations == nil {
+			numaInfo.Annotations = make(map[string]string)
+		}
+		// use to trigger CR numa update
+		numaInfo.Annotations["timestamp"] = fmt.Sprint(time.Now().Unix())
+
+		_, err := client.NodeinfoV1alpha1().Numatopologies().Update(context.TODO(), numaInfo, metav1.UpdateOptions{})
+		if err != nil {
+			klog.Errorf("Update Numatopo for node %s failed, err=%v", hostname, err)
+		} else {
+			klog.V(4).Infof("Updated Numatopo for node %s successfully", hostname)
+		}
 	}
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -18,11 +18,14 @@ package util
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	"volcano.sh/apis/pkg/apis/nodeinfo/v1alpha1"
 )
 
 // Parse string, such as "1,2-7,9,10-13,14"
@@ -96,4 +99,56 @@ func ParseResourceList(m map[string]string) (v1.ResourceList, error) {
 		}
 	}
 	return rl, nil
+}
+
+func SortPodAllocations(pas []v1alpha1.PodAllocation) {
+	sort.Slice(pas, func(i, j int) bool {
+		if pas[i].UID != pas[j].UID {
+			return pas[i].UID < pas[j].UID
+		}
+		if pas[i].Namespace != pas[j].Namespace {
+			return pas[i].Namespace < pas[j].Namespace
+		}
+		return pas[i].Name < pas[j].Name
+	})
+}
+
+func SortContainerAllocations(cas []v1alpha1.ContainerAllocation) {
+	sort.Slice(cas, func(i, j int) bool {
+		return cas[i].Name < cas[j].Name
+	})
+}
+
+// FormatCPUs converts a list of CPU IDs to a compact range string like "0-3,5,7-9".
+func FormatCPUs(cpus []int) string {
+	if len(cpus) == 0 {
+		return ""
+	}
+
+	sort.Ints(cpus)
+
+	var parts []string
+	start := cpus[0]
+	prev := cpus[0]
+
+	for i := 1; i < len(cpus); i++ {
+		if cpus[i] == prev+1 {
+			prev = cpus[i]
+			continue
+		}
+		parts = append(parts, formatRange(start, prev))
+		start = cpus[i]
+		prev = cpus[i]
+	}
+	parts = append(parts, formatRange(start, prev))
+
+	return strings.Join(parts, ",")
+}
+
+// formatRange formats a range of CPU IDs.
+func formatRange(start, end int) string {
+	if start == end {
+		return strconv.Itoa(start)
+	}
+	return fmt.Sprintf("%d-%d", start, end)
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2021 The Volcano Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	"volcano.sh/apis/pkg/apis/nodeinfo/v1alpha1"
+)
+
+func TestFormatCPUs(t *testing.T) {
+	testCases := []struct {
+		name   string
+		input  []int
+		expect string
+	}{
+		{name: "empty", input: []int{}, expect: ""},
+		{name: "single", input: []int{3}, expect: "3"},
+		{name: "contiguous", input: []int{0, 1, 2, 3}, expect: "0-3"},
+		{name: "mixed", input: []int{0, 1, 2, 5, 7, 8, 9}, expect: "0-2,5,7-9"},
+		{name: "unsorted input gets sorted", input: []int{9, 1, 0, 8, 7, 5, 2}, expect: "0-2,5,7-9"},
+		{name: "two singles", input: []int{3, 5}, expect: "3,5"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatCPUs(tc.input)
+			if got != tc.expect {
+				t.Fatalf("expected %q, got %q", tc.expect, got)
+			}
+		})
+	}
+}
+
+func TestFormatRange(t *testing.T) {
+	if got := formatRange(3, 3); got != "3" {
+		t.Fatalf("expected \"3\", got %q", got)
+	}
+	if got := formatRange(2, 5); got != "2-5" {
+		t.Fatalf("expected \"2-5\", got %q", got)
+	}
+}
+
+func TestSortContainerAllocations(t *testing.T) {
+	in := []v1alpha1.ContainerAllocation{
+		{Name: "z"},
+		{Name: "a"},
+		{Name: "m"},
+	}
+	SortContainerAllocations(in)
+	want := []string{"a", "m", "z"}
+	for i, c := range in {
+		if c.Name != want[i] {
+			t.Fatalf("idx %d: expected %q, got %q", i, want[i], c.Name)
+		}
+	}
+}
+
+func TestSortPodAllocations(t *testing.T) {
+	in := []v1alpha1.PodAllocation{
+		{UID: "uid2", Namespace: "nsA", Name: "podB"},
+		{UID: "uid1", Namespace: "nsB", Name: "podA"},
+		{UID: "uid1", Namespace: "nsA", Name: "podZ"},
+		{UID: "uid1", Namespace: "nsA", Name: "podA"},
+	}
+	SortPodAllocations(in)
+	want := []struct{ uid, ns, name string }{
+		{"uid1", "nsA", "podA"},
+		{"uid1", "nsA", "podZ"},
+		{"uid1", "nsB", "podA"},
+		{"uid2", "nsA", "podB"},
+	}
+	for i, w := range want {
+		if in[i].UID != w.uid || in[i].Namespace != w.ns || in[i].Name != w.name {
+			t.Fatalf("idx %d: expected %+v, got UID=%q NS=%q Name=%q",
+				i, w, in[i].UID, in[i].Namespace, in[i].Name)
+		}
+	}
+}
+
+func TestParseResourceList(t *testing.T) {
+	t.Run("empty map returns nil", func(t *testing.T) {
+		rl, err := ParseResourceList(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rl != nil {
+			t.Fatalf("expected nil, got %v", rl)
+		}
+	})
+
+	t.Run("valid cpu memory ephemeral", func(t *testing.T) {
+		rl, err := ParseResourceList(map[string]string{
+			string(v1.ResourceCPU):              "500m",
+			string(v1.ResourceMemory):           "1Gi",
+			string(v1.ResourceEphemeralStorage): "2Gi",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(rl) != 3 {
+			t.Fatalf("expected 3 entries, got %d", len(rl))
+		}
+	})
+
+	t.Run("negative quantity fails", func(t *testing.T) {
+		_, err := ParseResourceList(map[string]string{
+			string(v1.ResourceCPU): "-1",
+		})
+		if err == nil {
+			t.Fatalf("expected error for negative quantity")
+		}
+	})
+
+	t.Run("unsupported resource fails", func(t *testing.T) {
+		_, err := ParseResourceList(map[string]string{
+			"nvidia.com/gpu": "1",
+		})
+		if err == nil {
+			t.Fatalf("expected error for unsupported resource")
+		}
+	})
+
+	t.Run("invalid quantity fails", func(t *testing.T) {
+		_, err := ParseResourceList(map[string]string{
+			string(v1.ResourceCPU): "abc",
+		})
+		if err == nil {
+			t.Fatalf("expected error for invalid quantity")
+		}
+	})
+}


### PR DESCRIPTION
**Background**
Currently, resource-exporter reads the `cpu_manager_state` file from the node filesystem to discover the node's NUMA topology, and writes it into the numatopo CRD. However,
1.  this method has known limitations like [Kubernetes issues #118375](https://github.com/kubernetes/kubernetes/issues/118375).  Actually, the `cpu_manager_state` file is an internal implementation detail of the kubelet CPU manager and is not designed to be consumed externally. 
2.  resource-exporter fails to report the per-pod/container CPU allocation information, which may be required by system operators and components like volcano-scheduler.  

**What this PR does** 
First, since the PodResources API is the officially supported, stable, and recommended way to obtain pod/container resource allocation details from the kubelet, this PR introduces the PodResources API-based method to fetch the node's NUMA topology, which enhances the reliability of the numatopo CRD. Also, for the sake of compatibility, we add a new flag `--enable-pod-resource` to control which method is actually used. 
- When `true` (default): use the PodResources API-based method.
- When `false`: falls back to the `cpu_manager_state` file-based method.

Second, this PR enhances resource-exporter to report the pod/container‑level CPU allocation details, i.e., which CPUs are assigned to which container of which pod. This is because system operators sometimes need such information to pinpoint their issues. And more importantly, components like volcano-scheduler may need such information to make pod allocation decisions, especially after the appearance of [Volcano issues #5500](https://github.com/volcano-sh/volcano/issues/5500). Also, we make this ability available for both the PodResources API-based and the `cpu_manager_state` file-based method.