### PR TITLE
fix(numatopo): correct error handling and naming defects in cputopo

### DIFF
--- a/pkg/numatopo/cpunumainfo.go
+++ b/pkg/numatopo/cpunumainfo.go
@@ -304,12 +304,12 @@ func getCoreIDSocketIDForCpu(devicePath string, cpuID int) (coreID, socketID int
 	socketPath := filepath.Join(topoPath, "physical_package_id")
 	data, err = ioutil.ReadFile(socketPath)
 	if err != nil {
-		return 0, 0, fmt.Errorf("cpu %d read scoket_id file failed", cpuID)
+		return 0, 0, fmt.Errorf("cpu %d read socket_id file failed", cpuID)
 	}
 
 	tmpData, apiErr = util.Parse(string(data))
 	if apiErr != nil {
-		return 0, 0, fmt.Errorf("cpu %d scoket_id parse failed", cpuID)
+		return 0, 0, fmt.Errorf("cpu %d socket_id parse failed", cpuID)
 	}
 
 	socketID = tmpData[0]
@@ -320,7 +320,7 @@ func getCoreIDSocketIDForCpu(devicePath string, cpuID int) (coreID, socketID int
 // GetResourceInfoMap return the cpu topology info
 func (info *CPUNumaInfo) GetResourceInfoMap() v1alpha1.ResourceInfo {
 	sets := cpuset.New()
-	var cap = 0
+	var capacity = 0
 
 	for _, freeCpus := range info.NUMA2FreeCpus {
 		tmp := cpuset.New(freeCpus...)
@@ -328,12 +328,12 @@ func (info *CPUNumaInfo) GetResourceInfoMap() v1alpha1.ResourceInfo {
 	}
 
 	for numaID := range info.NUMA2CpuCap {
-		cap += info.NUMA2CpuCap[numaID]
+		capacity += info.NUMA2CpuCap[numaID]
 	}
 
 	return v1alpha1.ResourceInfo{
 		Allocatable: sets.String(),
-		Capacity:    cap,
+		Capacity:    capacity,
 	}
 }
 

--- a/pkg/numatopo/cpunumainfo.go
+++ b/pkg/numatopo/cpunumainfo.go
@@ -298,6 +298,9 @@ func getCoreIDSocketIDForCpu(devicePath string, cpuID int) (coreID, socketID int
 	if apiErr != nil {
 		return 0, 0, fmt.Errorf("cpu %d core_id parse failed", cpuID)
 	}
+	if len(tmpData) == 0 {
+		return 0, 0, fmt.Errorf("cpu %d core_id is empty", cpuID)
+	}
 
 	coreID = tmpData[0]
 
@@ -310,6 +313,9 @@ func getCoreIDSocketIDForCpu(devicePath string, cpuID int) (coreID, socketID int
 	tmpData, apiErr = util.Parse(string(data))
 	if apiErr != nil {
 		return 0, 0, fmt.Errorf("cpu %d socket_id parse failed", cpuID)
+	}
+	if len(tmpData) == 0 {
+		return 0, 0, fmt.Errorf("cpu %d socket_id is empty", cpuID)
 	}
 
 	socketID = tmpData[0]


### PR DESCRIPTION
## Summary

Small, self-contained correctness fixes in `pkg/numatopo/cputopo.go`. No dependency or behavior changes beyond corrected error reporting and panic prevention.

This is the first in a series of small PRs that split up the larger modernization effort from #14 into independently reviewable chunks. Partly fixes: https://github.com/volcano-sh/resource-exporter/issues/13 

## Changes

- **Handle ignored unmarshal error**: `checkpoint.UnmarshalCheckpoint(data)` return value was silently discarded. A malformed `cpu_manager_state` file would produce an empty checkpoint with no diagnostic. The error is now logged and the function returns early.
- **Log the correct error variable**: `getFreeCPUList` logged the already nil-checked `err` from the file read instead of `apiErr` from the parse step, so a parse failure printed `<nil>`.
- **Fix typo**: `scoket_id` -> `socket_id` in the two `physical_package_id` read/parse error messages.
- **Avoid shadowing builtin**: rename the local `cap` accumulator to `capacity` so it no longer shadows the builtin `cap()`.
- **Guard against empty parse results**: `util.Parse` returns an empty slice with a nil error for empty/newline-only input, so an empty `core_id` or `physical_package_id` sysfs file would pass the error check and then panic on `tmpData[0]`, crashing the exporter mid-poll. Both indexes are now length-guarded and fail gracefully with a descriptive error. **GEMINI SUGGESTED** added in the second commit.

## AI disclosure

I used AI for the PR creation and file edits. Checked every line, (its a small change after all).

## Testing

- `go build ./...` passes
- `go vet ./...` passes
- `go test ./...` passes
